### PR TITLE
Fix cook toggle not clickable

### DIFF
--- a/council.html
+++ b/council.html
@@ -690,8 +690,14 @@
 
         .toggle-switch input {
             opacity: 0;
-            width: 0;
-            height: 0;
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            top: 0;
+            left: 0;
+            cursor: pointer;
+            z-index: 1;
+            margin: 0;
         }
 
         .toggle-slider {


### PR DESCRIPTION
The checkbox input had width/height of 0, making it unclickable. Now it covers the full toggle area with absolute positioning.